### PR TITLE
Fix: Make project page show up first for now, instead of onboarding page

### DIFF
--- a/lib/pages/bottom_nav_pages/bottom_nav_page.dart
+++ b/lib/pages/bottom_nav_pages/bottom_nav_page.dart
@@ -22,7 +22,7 @@ class _BottomNavPageState extends State<BottomNavPage> {
     DonatePage(),
   ];
 
-  int _selectedPage = 0;
+  int _selectedPage = 1;
 
   void onTap(int index) {
     setState(() {

--- a/lib/pages/bottom_nav_pages/career_page.dart
+++ b/lib/pages/bottom_nav_pages/career_page.dart
@@ -8,7 +8,7 @@ class CareerPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Career',
-      bodyContent: 'COMING SOON...',
+      bodyContent: 'Coming Soon',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/career_page.dart
+++ b/lib/pages/bottom_nav_pages/career_page.dart
@@ -8,7 +8,7 @@ class CareerPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Career',
-      bodyContent: 'Coming Soon',
+      bodyContent: 'Coming soon',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/career_page.dart
+++ b/lib/pages/bottom_nav_pages/career_page.dart
@@ -8,8 +8,7 @@ class CareerPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Career',
-      bodyContent:
-          'Welcome to the career page. Which career path interest you 🤔',
+      bodyContent: 'COMING SOON...',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/donate_page.dart
+++ b/lib/pages/bottom_nav_pages/donate_page.dart
@@ -8,7 +8,7 @@ class DonatePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Donation',
-      bodyContent: 'Coming Soon',
+      bodyContent: 'Coming soon',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/donate_page.dart
+++ b/lib/pages/bottom_nav_pages/donate_page.dart
@@ -8,8 +8,7 @@ class DonatePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Donation',
-      bodyContent:
-          'Welcome to the donation page, what will you to be sharing with us as donations 😁',
+      bodyContent: 'COMING SOON...',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/donate_page.dart
+++ b/lib/pages/bottom_nav_pages/donate_page.dart
@@ -8,7 +8,7 @@ class DonatePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Donation',
-      bodyContent: 'COMING SOON...',
+      bodyContent: 'Coming Soon',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/onboarding_page.dart
+++ b/lib/pages/bottom_nav_pages/onboarding_page.dart
@@ -8,7 +8,7 @@ class OnboardingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Onboarding',
-      bodyContent: 'COMING SOON...',
+      bodyContent: 'Coming Soon',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/onboarding_page.dart
+++ b/lib/pages/bottom_nav_pages/onboarding_page.dart
@@ -8,8 +8,7 @@ class OnboardingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Onboarding',
-      bodyContent:
-          'Welcome to the onboarding page, this things you need to know about the project 🚀.',
+      bodyContent: 'COMING SOON...',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/onboarding_page.dart
+++ b/lib/pages/bottom_nav_pages/onboarding_page.dart
@@ -8,7 +8,7 @@ class OnboardingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Onboarding',
-      bodyContent: 'Coming Soon',
+      bodyContent: 'Coming soon',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/project_page.dart
+++ b/lib/pages/bottom_nav_pages/project_page.dart
@@ -8,7 +8,7 @@ class ProjectPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Project',
-      bodyContent: 'Welcome to the project page, choose a project to work on.',
+      bodyContent: 'Welcome to the project page, choose a project to work on 🧐.',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/project_page.dart
+++ b/lib/pages/bottom_nav_pages/project_page.dart
@@ -8,8 +8,7 @@ class ProjectPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Project',
-      bodyContent:
-          'Welcome to the project page, choose a project to work on 🧐.',
+      bodyContent: 'Welcome to the project page, choose a project to work on.',
     );
   }
 }

--- a/lib/pages/bottom_nav_pages/project_page.dart
+++ b/lib/pages/bottom_nav_pages/project_page.dart
@@ -8,7 +8,8 @@ class ProjectPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const ReusedScaffold(
       appTitle: 'Project',
-      bodyContent: 'Welcome to the project page, choose a project to work on 🧐.',
+      bodyContent:
+          'Welcome to the project page, choose a project to work on 🧐.',
     );
   }
 }


### PR DESCRIPTION
**This pull request makes the following changes**

- Fixes issue (https://discordapp.com/channels/1148391778492354741/1253584233155395657/1260019224017895576)

**General Checklist**

- [x] Making the Project screen display first.
- [x] Text on the body of other screens change to "Coming Soon".


**Testing Checklist:**

- Project page/screen now shows up first instead of the onboarding screen.
- Project page/screen content is the same as before.
- The other screens have only "Coming soon" text in them. 
